### PR TITLE
ポートフォワーディング修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         volumes:
             - ./notebook/:/home/jovyan/notebook
         ports:
-            - 80:8888
+            - 8888:8888
         environment:
             NVIDIA_VISIBLE_DEVICES: all
             NVIDIA_DRIVER_CAPABILITIES: all


### PR DESCRIPTION
非常に参考になるQiitaの記事とコードでした。本当にありがとうございます。
ポートフォワーディングの部分でjupyterの起動ポートがdefaultで8888になっているので修正しました。